### PR TITLE
Fix open images for Android 13

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -16,9 +16,16 @@
       </feature>
     </config-file>
     <config-file parent="/manifest/application" target="AndroidManifest.xml">
-        <provider android:name="android.support.v4.content.FileProvider" android:authorities="${applicationId}.provider" android:exported="false" android:grantUriPermissions="true">
-            <meta-data android:name="android.support.FILE_PROVIDER_PATHS" android:resource="@xml/provider_paths"/>
-        </provider>
+      <provider
+        android:name="androidx.core.content.FileProvider"
+        android:authorities="${applicationId}.provider"
+        android:exported="false"
+        android:grantUriPermissions="true">
+          <meta-data
+            android:name="android.support.FILE_PROVIDER_PATHS"
+            android:resource="@xml/provider_paths" 
+          />
+      </provider>
     </config-file>
     <source-file src="src/android/Open.java" target-dir="src/com/disusered"/>
     <source-file src="src/android/provider_paths.xml" target-dir="res/xml"/>

--- a/src/android/Open.java
+++ b/src/android/Open.java
@@ -65,14 +65,12 @@ public class Open extends CordovaPlugin {
                 Uri uri = Uri.parse(path);
                 String mime = getMimeType(path);
                 Intent fileIntent = new Intent(Intent.ACTION_VIEW);
-                Context context = cordova.getActivity().getApplicationContext();
 
                 // see http://stackoverflow.com/questions/25592206/how-to-get-your-context-in-your-phonegap-plugin
                 if (Build.VERSION.SDK_INT >= 24) {
                     Context context = cordova.getActivity().getApplicationContext();
                     File imageFile = new File(uri.getPath());
-                    Uri photoURI = FileProvider.getUriForFile(context, context.getPackageName() + ".provider", imageFile);
-                    fileIntent.setDataAndTypeAndNormalize(photoURI, mime);
+                    Uri photoURI = FileProvider.getUriForFile(context, context.getApplicationContext().getPackageName() + ".provider", imageFile);                    fileIntent.setDataAndTypeAndNormalize(photoURI, mime);
                     // see http://stackoverflow.com/questions/39450748/intent-shows-a-blank-image
                     fileIntent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_GRANT_READ_URI_PERMISSION);
                 } else if (Build.VERSION.SDK_INT > 15) {

--- a/src/android/Open.java
+++ b/src/android/Open.java
@@ -9,7 +9,7 @@ import org.json.JSONException;
 import android.content.Context;
 import android.net.Uri;
 import android.content.Intent;
-import android.support.v4.content.FileProvider;
+import androidx.core.content.FileProvider;
 import android.webkit.MimeTypeMap;
 import android.content.ActivityNotFoundException;
 import android.os.Build;
@@ -65,12 +65,13 @@ public class Open extends CordovaPlugin {
                 Uri uri = Uri.parse(path);
                 String mime = getMimeType(path);
                 Intent fileIntent = new Intent(Intent.ACTION_VIEW);
+                Context context = cordova.getActivity().getApplicationContext();
 
                 // see http://stackoverflow.com/questions/25592206/how-to-get-your-context-in-your-phonegap-plugin
                 if (Build.VERSION.SDK_INT >= 24) {
                     Context context = cordova.getActivity().getApplicationContext();
                     File imageFile = new File(uri.getPath());
-                    Uri photoURI = FileProvider.getUriForFile(context, context.getApplicationContext().getPackageName() + ".provider", imageFile);
+                    Uri photoURI = FileProvider.getUriForFile(context, context.getPackageName() + ".provider", imageFile);
                     fileIntent.setDataAndTypeAndNormalize(photoURI, mime);
                     // see http://stackoverflow.com/questions/39450748/intent-shows-a-blank-image
                     fileIntent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_GRANT_READ_URI_PERMISSION);

--- a/www/disusered.open.js
+++ b/www/disusered.open.js
@@ -42,9 +42,7 @@ exports.open = function(uri, success, error, progress, trustAllCertificates) {
  */
 function downloadAndOpen(url, success, error, progress, trustAllCertificates) {
   var ft = new FileTransfer();
-  var ios = cordova.file.cacheDirectory;
-  var ext = cordova.file.externalCacheDirectory;
-  var dir = (ext) ? ext : ios;
+  var dir = cordova.file.cacheDirectory;
   var name = url.substring(url.lastIndexOf('/') + 1);
   var path = dir + name;
 
@@ -59,7 +57,7 @@ function downloadAndOpen(url, success, error, progress, trustAllCertificates) {
 
   ft.download(url, path,
       function done(entry) {
-        var file = entry.toURL();
+        var file = entry.nativeURL;
         exec(onSuccess.bind(this, file, success),
              onError.bind(this, error), 'Open', 'open', [file]);
       },


### PR DESCRIPTION
## Link to task details
https://tutormundi.larksuite.com/record/I8N1rTOy5edK1McTz1ZuVvv4sEq

## Summary of changes

- Update for androidX provider
- Use `nativeURL` instead of `toURL()`
- Remove `externalCacheDirectory` and use only `cacheDirectory`

## Did you?

Cordova changes

- [x]  test on iOS app
- [x] test on Android app
- [ ] test on desktop - NA
- [ ] update the mobile version number - NA